### PR TITLE
Gateway cli to send the sign request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayref"
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -891,15 +891,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9724adfcf41f45bf652b3995837669d73c4d49a1b5ac1ff82905ac7d9b5558"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
  "syn 2.0.100",

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # mpc-signing
+
+
+## MPC Signing with trusted dealer:
+
+In one terminal, start the dealer, who is listening on 127.0.0.1:50052:
+
+```bash
+cargo run -p dealer
+```
+
+And in another terminal, run the gateway to send the signing request:
+
+
+```bash
+cargo run -p gateway -- --max-signers <MAX> --min-signers <MIN> sign <LABEL> <MESSAGE>
+```
+

--- a/dealer/src/dealer.rs
+++ b/dealer/src/dealer.rs
@@ -71,11 +71,9 @@ impl Gateway for Dealer {
         let req = request.into_inner();
         // === Generate FROST key shares ===
         let mut rng = thread_rng();
-        let max_signers = 3;
-        let min_signers = 2;
         let (shares, pubkey_package) = frost_ed25519::keys::generate_with_dealer(
-            max_signers,
-            min_signers,
+            req.max_signers as u16,
+            req.min_signers as u16,
             frost_ed25519::keys::IdentifierList::Default,
             &mut rng,
         )

--- a/gateway/src/gateway.rs
+++ b/gateway/src/gateway.rs
@@ -17,9 +17,12 @@ impl GatewayGrpcClient {
     }
 
     async fn connect_client(&self) -> anyhow::Result<GatewayClient<Timeout<Channel>>> {
-        let endpoint = Endpoint::from_static("https://hardcoded-endpoint.example.com")
-            .tls_config(tonic::transport::ClientTlsConfig::new())?;
-        let channel = endpoint.connect().await?;
+        let endpoint = "http://127.0.0.1:50052";
+        let channel = Endpoint::from_shared(endpoint)
+            .map_err(|e| anyhow::anyhow!("Failed to create endpoint: {}", e))?
+            .connect()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to connect to gRPC server: {}", e))?;
         let timeout_channel = Timeout::new(channel, std::time::Duration::from_millis(5000));
         let client = GatewayClient::new(timeout_channel);
         Ok(client)

--- a/gateway/src/gateway.rs
+++ b/gateway/src/gateway.rs
@@ -1,16 +1,15 @@
-use anyhow::Result;
 use proto_api::mpc_gateway::{gateway_client::GatewayClient, SignRequest};
 use tonic::transport::{Channel, Endpoint};
 use tower::timeout::Timeout;
 
 #[derive(Debug, Clone)]
 pub struct GatewayGrpcClient {
-    pub max_signers: u8,
-    pub min_signers: u8,
+    pub max_signers: i32,
+    pub min_signers: i32,
 }
 
 impl GatewayGrpcClient {
-    pub fn new(max_signers: u8, min_signers: u8) -> Result<Self> {
+    pub fn new(max_signers: i32, min_signers: i32) -> anyhow::Result<Self> {
         Ok(Self {
             max_signers,
             min_signers,
@@ -28,8 +27,8 @@ impl GatewayGrpcClient {
 
     pub async fn sign(&self, label: String, data: Vec<u8>) -> anyhow::Result<Vec<u8>> {
         let req = SignRequest {
-            max_signers: (self.max_signers as u32).to_string(),
-            min_signers: (self.min_signers as u32).to_string(),
+            max_signers: self.max_signers,
+            min_signers: self.min_signers,
             label,
             message: data,
         };

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -11,9 +11,9 @@ struct Cli {
     #[clap(subcommand)]
     command: Commands,
     #[arg(long)]
-    max_signers: u8,
+    max_signers: i32,
     #[arg(long)]
-    min_signers: u8,
+    min_signers: i32,
 }
 
 #[derive(Subcommand)]

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
                 message
             );
 
-            let message_bytes = hex::decode(message).expect("hexadecimal string");
+            let message_bytes = message.as_bytes().to_vec();
             let sig = client.sign(label.clone(), message_bytes).await?;
             println!("Signature: {:?}", hex::encode(sig));
         }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "p2p"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libp2p = { version = "0.53", features = [
+    "rendezvous",
+    "async-std",
+    "dns",
+    "gossipsub",
+    "mdns",
+    "noise",
+    "macros",
+    "request-response",
+    "tcp",
+    "tokio",
+    "yamux",
+    "identify",
+    "ping",
+    "cbor",
+    "serde",
+] }
+serde = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }

--- a/p2p/src/client.rs
+++ b/p2p/src/client.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+pub type KeyId = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawProtocolMessage {
+    pub session_id: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum Command {}

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,0 +1,57 @@
+#[warn(dead_code)]
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+mod client;
+use libp2p::{
+    gossipsub, mdns,
+    rendezvous::{self, Cookie},
+    swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
+};
+use tokio::sync::mpsc;
+pub type PeerId = libp2p::PeerId;
+
+pub use crate::client::*;
+#[derive(Debug)]
+pub enum Event {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolExecutionParams {
+    pub protocol: String,
+    pub key_id: KeyId,
+    pub peer_ids: Vec<PeerId>,
+    pub data: Option<Vec<u8>>,
+}
+#[derive(NetworkBehaviour)]
+struct _NodeBehavior {
+    ping: libp2p::ping::Behaviour,
+    rendezvous_server: Toggle<rendezvous::server::Behaviour>,
+    rendezvous_client: Toggle<rendezvous::client::Behaviour>,
+    gossipsub: gossipsub::Behaviour,
+    mdns: Toggle<mdns::tokio::Behaviour>,
+}
+
+pub struct Node {
+    #[allow(dead_code)]
+    swarm: String,
+    #[allow(dead_code)]
+    rendezvous_point: Option<PeerId>,
+    #[allow(dead_code)]
+    rendezvous_cookie: Option<Cookie>,
+    #[allow(dead_code)]
+    message_sender: mpsc::UnboundedSender<RawProtocolMessage>,
+}
+
+impl Node {
+    pub fn new(
+        _command_receiver: mpsc::UnboundedReceiver<Command>,
+        message_sender: mpsc::UnboundedSender<RawProtocolMessage>,
+        _event_sender: mpsc::UnboundedSender<Event>,
+    ) -> Result<Self> {
+        Ok(Self {
+            swarm: String::new(),
+            rendezvous_point: None,
+            rendezvous_cookie: None,
+            message_sender,
+        })
+    }
+}

--- a/proto_api/proto/gateway.proto
+++ b/proto_api/proto/gateway.proto
@@ -19,8 +19,8 @@ message CreateReply {
 
 
 message SignRequest {
-  string max_signers = 1;
-  string min_signers = 2;
+  int32 max_signers = 1;
+  int32 min_signers = 2;
   string label = 3;
   bytes message = 4;
 }


### PR DESCRIPTION
This PR matches the type of `max_signers` and `min_signers`  and allows to execute the CLI in the next form:

In one terminal the dealer listening on 127.0.0.1:50052:

```bash
cargo run -p dealer
```

And another terminal to send the gateway request:


```bash
cargo run -p gateway -- --max-signers <MAX> --min-signers <MIN> sign <LABEL> <MESSAGE>
```